### PR TITLE
Add Hanzilla Jobs to job boards

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ A curated list of awesome job seeking resources
 * [tealhq](https://www.tealhq.com/)
 * [weworkremotely](https://weworkremotely.com/)
 * [ycombinator](https://news.ycombinator.com/jobs)
+* [Hanzilla Jobs](https://jobs.hanzilla.co/)
 
 ## Application Tracking
 


### PR DESCRIPTION
## Summary

Add Hanzilla Jobs to the Job Boards section.

Hanzilla Jobs is a free, daily-updated Canadian student and recent-grad jobs board covering internships, co-ops, new grad, junior, and entry-level roles across tech, finance, engineering, business, sciences, and more.

Link: https://jobs.hanzilla.co/

## Checklist

- [x] Searched existing list for duplicates
- [x] Added one suggestion to the relevant category
- [x] Kept the format consistent with existing entries
