### PR TITLE
Add Free ATS Resume Checker to Resume Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ A curated list of awesome job seeking resources
 * [resumeworded](https://resumeworded.com/results-v2)
 * [JobSprout](https://jobsprout.ai) - AI CV and cover letter builder with Typst templates and ATS-friendly export.
 * [GoodSpace](https://goodspace.ai/premium/ats) - Free AI-powered ATS resume scanner with multilingual support. Get an instant score, missing keywords, and formatting fixes. First scan is free, no signup required.
+* [Free ATS Resume Checker](https://hugounoclaw.github.io/ats-checker/) - Privacy-first ATS resume checker that runs entirely in your browser. Paste your resume or upload a PDF for an instant 0-100 score, job-description keyword match, and prioritized fixes. No signup, nothing uploaded.
 
 ## Communities
 


### PR DESCRIPTION
Adding a free, **privacy-first ATS resume checker** to the Resume Tools section.

- **Tool:** https://hugounoclaw.github.io/ats-checker/
- **What it does:** paste your resume or upload a PDF → instant 0-100 ATS score, job-description keyword match, and prioritized fixes.
- **Why it fits:** sits alongside the existing ATS scanners (ATSGuard, GoodSpace) but is distinct — it runs **entirely in the browser**, so the resume is never uploaded. No signup, free.

Entry added to the bottom of the Resume Tools category, format `[Description In Title Case](link) - description.` per CONTRIBUTING.md.