### PR TITLE
Add FoundRole to Job Boards

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ A curated list of awesome job seeking resources
 * [weworkremotely](https://weworkremotely.com/)
 * [ycombinator](https://news.ycombinator.com/jobs)
 * [Hanzilla Jobs](https://jobs.hanzilla.co/)
+* [FoundRole](https://www.foundrole.com/)
 
 ## Application Tracking
 


### PR DESCRIPTION
## What is FoundRole?

FoundRole is a free AI job search platform built for job seekers who are tired of juggling multiple tools. It combines a job board with hourly-updated listings, a Kanban application tracker for managing your pipeline, and career market analytics — all in one place, free, with no credit-card walls.

**What makes it different:**

- Job board and application tracker in one product — search, save, and track without switching tabs
- Kanban board to manage every application stage, replacing spreadsheets and sticky notes
- Market analytics to understand hiring trends alongside your job search
- MCP integration so AI assistants (Claude, ChatGPT) can search jobs and update your tracker from chat

**Why the Job Boards section:** FoundRole is a general-purpose job search platform — the same category as seek, indeed, and LinkedIn Jobs. The home page is the canonical destination, matching the format of every existing entry in the section.

Link: https://www.foundrole.com