### PR TITLE
Add ApplyKit to Resume Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ A curated list of awesome job seeking resources
 * [resumeworded](https://resumeworded.com/results-v2)
 * [JobSprout](https://jobsprout.ai) - AI CV and cover letter builder with Typst templates and ATS-friendly export.
 * [GoodSpace](https://goodspace.ai/premium/ats) - Free AI-powered ATS resume scanner with multilingual support. Get an instant score, missing keywords, and formatting fixes. First scan is free, no signup required.
+* [ApplyKit](https://applykit-beryl.vercel.app) - AI resume tailoring, cover letter, and interview prep built from your actual background, grounded in Gemini. Free tier available.
 
 ## Communities
 


### PR DESCRIPTION
Adds ApplyKit — AI resume tailoring, cover letter, and interview prep built from a candidate's actual background (grounded via Gemini, not generic templates). Free tier available. One-line addition to Resume Tools, following the existing entry format.